### PR TITLE
Change "IT positions" to "technical positions"

### DIFF
--- a/pages/phases/job-announcement.md
+++ b/pages/phases/job-announcement.md
@@ -28,7 +28,7 @@ These IT Specialist job announcements were posted by our agency pilot participan
     </li>
     <li class="chp-toolkit__item">
       <a href="{{ site.baseurl }}/hiring-phases/recruitment/technology-job-boards/" class="chp-toolkit__link">
-        Useful job boards for IT positions
+        Useful job boards for technical positions
       </a>
     </li>
   </ul>


### PR DESCRIPTION
@humancompanion did a search across the repository for "IT" and found one instance where it should be described as the broader "technical" term instead (https://github.com/usds/OPM_pilot/issues/359). This fixes that.