### PR TITLE
Various Jekyll site updates to the home page and general navigation headers

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -12,7 +12,7 @@ primary:
 about:
   - text: The SME-QA Process
     href: /about/our-process/
-  - text: How the SME-QA Process is Different
+  - text: How SME-QA is Different
     href: /about/differences/
 
 hiring-phases:

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,5 +1,5 @@
 primary:
-  - text: About Our Process
+  - text: About SME-QA
     href: /
     name: about
   - text: Begin Your Hiring Action
@@ -10,13 +10,13 @@ primary:
     name: case-studies
 
 about:
-  - text: Our process
+  - text: The SME-QA Process
     href: /about/our-process/
-  - text: How our process is different
+  - text: How the SME-QA Process is Different
     href: /about/differences/
 
 hiring-phases:
-  - text: Getting started
+  - text: Getting Started
     href: /hiring-phases/getting-started/
     subnav:
     - text: Identifying Appropriate Positions
@@ -29,7 +29,7 @@ hiring-phases:
   - text: Assessment Strategy
     href: /hiring-phases/assessment-strategy/
     phase: assessment-strategy
-  - text: Job analysis workshop
+  - text: Job Analysis Workshop
     href: /hiring-phases/job-analysis/
     phase: job-analysis
     subnav:
@@ -45,7 +45,7 @@ hiring-phases:
       href: "/hiring-phases/job-analysis/defining-proficiency-levels/"
     - text: Creating a Structured Interview from Competencies
       href: "/hiring-phases/job-analysis/creating-a-structured-interview-from-competencies"
-  - text: Job announcement
+  - text: Job Announcement
     href: /hiring-phases/job-announcement/
     phase: job-announcement
     subnav:

--- a/_includes/_banner-beta.html
+++ b/_includes/_banner-beta.html
@@ -1,5 +1,5 @@
 <div class="chp-banner--beta u-background-color--gold u-padding-y--2">
   <div class="chp-banner--beta__body">
-    <p class="chp-banner--beta__text"><strong>This hiring pilot is only available to HHS, DOI, and GSA.</strong> To learn how to get your agency involved, <a href="https://github.com/labopm/competitive-hiring-pilot/issues/new?template=contact_us.md" class="chp-banner--beta__link">contact us</a>.</p>
+    <p class="chp-banner--beta__text"><strong>The SME-QA process is available to particular offices at HHS, DOI, and GSA.</strong> To learn how your agency can use SME-QA to find talented public servants, <a href="https://github.com/labopm/competitive-hiring-pilot/issues/new?template=contact_us.md" class="chp-banner--beta__link">contact us</a>.</p>
   </div>
 </div>

--- a/_includes/_header.html
+++ b/_includes/_header.html
@@ -5,7 +5,7 @@
       <div class="usa-logo" id="basic-mega-logo">
         <em class="usa-logo__text">
           <a href="{{ site.baseurl }}/" title="Home" aria-label="Home">
-            Competitive Hiring Pilot
+            SME-QA Hiring Process
           </a>
         </em>
       </div>

--- a/pages/home.html
+++ b/pages/home.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: During a typical competitive delegated examining hiring process, human resource (HR) specialists review resumes and occupational questionnaires to determine whether applicants are minimally qualified for a role. Agencies often conduct outreach and recruitment for technical positions and are concerned when they receive certificates without truly qualified applicants to select from. With this assessment alternative, SMEs partner with HR specialists to create and conduct interview assessments before considering an applicant qualified and applying veterans’ preference. This process is recommended for GS 12+ technical positions (not limited to IT) with at least five vacancies for the same role and where applicant volume can be limited to approximately 100 applicants.
+description: During a typical competitive delegated examining hiring process, human resource (HR) specialists review resumes and occupational questionnaires to determine whether applicants are minimally qualified for a role. Agencies often conduct outreach and recruitment for technical positions and are concerned when they receive certificates without truly qualified applicants to select from.
 section: home
 permalink: /
 ---
@@ -10,6 +10,9 @@ permalink: /
   <h1 class="chp-hero__title">USDS + OPM Competitive Hiring Pilot</h1>
   <p class="chp-hero__desc">
     {{ page.description }}
+  </p>
+  <p>
+    With the SME-QA alternative, SMEs partner with HR specialists to create and conduct interview assessments before considering an applicant qualified and applying veterans’ preference. The SME-QA process is recommended for GS-12 or higher technical positions (not limited to IT) with at least five vacancies for the same role where applicant volume can be limited to approximately 100 applicants.
   </p>
 </div>
 <div class="grid-container chp-home-features">

--- a/pages/home.html
+++ b/pages/home.html
@@ -22,7 +22,7 @@ permalink: /
         </div>
         <div class="chp-home-featured__body">
           <p>
-            Learn How to Qualify Applicants using SMEs
+            Learn what it takes to qualify applicants using the Subject Matter Expert Qualification Assessment (SME-QA) process.
           </p>
         </div>
       </a>
@@ -35,7 +35,7 @@ permalink: /
         </div>
         <div class="chp-home-featured__body">
           <p>
-            Start with job analysis and follow our guide all the way through to a certificate filled with qualified candidates that you want to hire.
+            When you've decided to find qualified applicants using the SME-QA process, you can plan your hiring action.
           </p>
         </div>
       </a>
@@ -48,7 +48,7 @@ permalink: /
         </div>
         <div class="chp-home-featured__body">
           <p>
-            Read case studies on our work thus far.
+            Read case studies on agencies that have used the SME-QA process to find talented applicants thus far.
           </p>
         </div>
       </a>

--- a/pages/home.html
+++ b/pages/home.html
@@ -1,6 +1,6 @@
 ---
 layout: default
-description: The USDS/OPM Pilot deploys resume review as a pre-qualification for an overall passing score assessment. Applicants who receive a passing score  from SME phone interviews are considered qualified for preference and category ratings.
+description: During a typical competitive delegated examining hiring process, human resource (HR) specialists review resumes and occupational questionnaires to determine whether applicants are minimally qualified for a role. Agencies often conduct outreach and recruitment for technical positions and are concerned when they receive certificates without truly qualified applicants to select from. With this assessment alternative, SMEs partner with HR specialists to create and conduct interview assessments before considering an applicant qualified and applying veterans’ preference. This process is recommended for GS 12+ technical positions (not limited to IT) with at least five vacancies for the same role and where applicant volume can be limited to approximately 100 applicants.
 section: home
 permalink: /
 ---

--- a/pages/home.html
+++ b/pages/home.html
@@ -7,7 +7,7 @@ permalink: /
 
 {% include _banner-beta.html %}
 <div class="grid-container margin-y-5">
-  <h1 class="chp-hero__title">USDS + OPM Competitive Hiring Pilot</h1>
+  <h1 class="chp-hero__title">Subject Matter Expert Qualification Assessments (SME-QA)</h1>
   <p class="chp-hero__desc">
     {{ page.description }}
   </p>

--- a/pages/home.html
+++ b/pages/home.html
@@ -6,32 +6,6 @@ permalink: /
 ---
 
 {% include _banner-beta.html %}
-<div class="chp-home-hero">
-  <div class="grid-container chp-home-hero__body">
-    <h4 class="chp-home__sub-title">The problem we are solving</h4>
-    <p class="usa-intro chp-home-hero__callout">
-      For technical positions in the competitive service, <strong>hiring managers often cannot select truly qualified candidates</strong> from the certificate.
-    </p>
-    <div class="chp-home-certs__container">
-      <div class="grid-row">
-        <div class="chp-home-certs">
-          <h2 class="chp-home-certs__stat">&gt; 50%</h2>
-          <h4 class="chp-home-certs__desc">Certificates canceled</h4>
-        </div>
-        <div class="chp-home-certs">
-          <h2 class="chp-home-certs__stat">~ 2/3</h2>
-          <h4 class="chp-home-certs__desc">Technical role certificates canceled</h4>
-        </div>
-      </div>
-    </div>
-
-    <p class="chp-home-hero__lead">
-      <strong>
-        Only ~20% of employees were hired via delegated examining into the competitive service in 2017.
-      </strong>
-    </p>
-  </div>
-</div>
 <div class="grid-container margin-y-5">
   <h1 class="chp-hero__title">USDS + OPM Competitive Hiring Pilot</h1>
   <p class="chp-hero__desc">


### PR DESCRIPTION
Stephanie gave me a punch list of things to update on the Jekyll site. Going through those here.

- Update home page intro to use intro paragraph from the one-sheet (closes https://github.com/usds/OPM_pilot/issues/730)
- Remove the "two red X" graphic from homepage (closes https://github.com/usds/OPM_pilot/issues/728)
- Use "SME-QA" in navigation (partially addresses https://github.com/usds/OPM_pilot/issues/729)