### PR TITLE
[WIP] Change references to "the process" to reference SME-QA

### DIFF
--- a/pages/about/differences.html
+++ b/pages/about/differences.html
@@ -2,8 +2,8 @@
 layout: default
 section: about
 permalink: /about/differences/
-title: How our process is different
-intro: In the current competitive hire process, agencies use HR resume review and occupational questionnaires to determine whether a candidate is “minimally qualified.” Applicants who pass this step are automatically “eligible” for quality category placement and veterans’ preference application. The OPM-USDS Pilot instead deploys a subject matter expert (SME) resume review step as a pre-qualification for an overall passing score assessment. HR adjudicates and applies veterans’ preference only to those applicants who achieve the overall passing score after the second interview. HR works with SMEs during a job analysis workshop to develop the competencies, proficiency levels, and structured interview questions that will define the assessments. If the agency has IO Psychologists available, they are encouraged to participate.
+title: How SME-QA is Different
+intro: In the current competitive hire process, agencies use HR resume review and occupational questionnaires to determine whether a candidate is “minimally qualified.” Applicants who pass this step are automatically “eligible” for quality category placement and veterans’ preference application. The SME-QA process instead deploys a subject matter expert (SME) resume review step as a pre-qualification for an overall passing score assessment. HR adjudicates and applies veterans’ preference only to those applicants who achieve the overall passing score after the second interview. HR works with SMEs during a job analysis workshop to develop the competencies, proficiency levels, and structured interview questions that will define the assessments. If the agency has IO Psychologists available, they are encouraged to participate.
 ---
 
 <main id="main-content" role="main" class="usa-layout-docs usa-section chp-article">

--- a/pages/about/our-process.html
+++ b/pages/about/our-process.html
@@ -2,8 +2,8 @@
 layout: default
 section: about
 permalink: /about/our-process/
-title: Our process
-intro: In the typical competitive delegated examining hiring process, HR specialists review resumes and occupational questionnaires to determine that applicants are minimally qualified. Hiring managers often know that qualified people have applied for their open role, but receive delegated examining certificates without truly qualified applicants to select. The Competitive Hiring Pilot introduces subject matter experts (SMEs), in partnership with HR specialists as guides, to create and conduct interview assessments before an applicant is considered qualified. HR specialists protect merit principles and ensure that participants the documented assessment strategy is applied consistently.
+title: The SME-QA Process
+intro: The SME-QA process introduces subject matter experts (SMEs), in partnership with HR specialists as guides, to create and conduct interview assessments before an applicant is considered qualified. HR specialists protect merit principles and ensure that participants the documented assessment strategy is applied consistently.
 ---
 
 {% include _banner-beta.html %}

--- a/pages/phases/certificate.md
+++ b/pages/phases/certificate.md
@@ -24,7 +24,7 @@ roles: [hr, hiring-mgr]
   <div class="usa-alert__body">
     <h3 class="usa-alert__heading">Do not conduct a separate minimum qualification review</h3>
     <p class="usa-alert__text">
-      After SMEs have completed interviews and identified the applicants who are found to meet qualifications, do not conduct a separate minimum qualification review. For the duration of the hiring action, SMEs have used their expertise and technical ability to assess whether an applicant is truly qualified before being considered minimally qualified and eligible for Veterans' Preference. As the HR specialist, you've reviewed every justification after each assessment to ensure it was rooted in one of the technical qualifications. No additional minimum qualification check is required. For more information, see "<a href="{{ site.baseurl }}/about/differences/#sme-assessment">How our process is different</a>."
+      SMEs have used their expertise and technical ability to assess whether an applicant is truly qualified before being considered minimally qualified and eligible for veterans' preference. As the HR specialist, you've reviewed every justification after each assessment to ensure it was rooted in one of the technical qualifications. For more information, see "<a href="{{ site.baseurl }}/about/differences/#sme-assessment">How SME-QA is Different</a>."
     </p>
   </div>
 </div>
@@ -41,7 +41,7 @@ To pass over a veteran, hiring managers must meet the requirements of 5 U.S.C. Â
 
 ## Selecting Qualified Applicants from a Certificate
 
-When hiring with this process, there should be *fewer* applicants who make it to onto the certificate based on their qualifications and *more* selections off of the delegated examining certificates. Ideally, the extraordinary SME review process that confirms that an applicant meets the required technical qualifications will allow qualified applicants to receive offers for positions at an agency. If there are more qualified applicants on a certificate than available billets at an agency, that agency may choose to share the certificate with other groups or agencies.
+When using the SME-QA process, there should be *fewer* applicants who make it to the certificate based on their qualifications, and hiring managers should be able to make *more* selections off of the certificates. Ideally, the extraordinary SME review process that confirms that an applicant meets the required technical qualifications will allow these applicants to receive offers for positions at an agency. If there are more qualified applicants on a certificate than vacancies at an agency, that agency may choose to share the certificate with other offices or agencies.
 
 ## Post-Selection
 

--- a/pages/phases/getting-started/index.html
+++ b/pages/phases/getting-started/index.html
@@ -2,10 +2,10 @@
 layout: article
 permalink: /hiring-phases/getting-started/
 section: hiring-phases
-title: Getting started
+title: Getting Started
 sidenav: hiring-phases
 phase: getting-started
-intro: When you've decided to find qualified applicants using this process, you can plan your hiring action.
+intro: When you've decided to use the SME-QA process to find qualified applicants, you can plan your hiring action.
 roles: [hr, hiring-mgr]
 duration: 1 day (8 hours)
 outputs:
@@ -21,7 +21,7 @@ outputs:
   {{ page.intro }}
 </p>
 <p>
-  For more information, see <a href="{{ site.baseurl }}/about/our-process/">About Our Process</a>.
+  For more information, see <a href="{{ site.baseurl }}/about/our-process/">The SME-QA Process</a>.
 </p>
 
 {% include phase-meta.html %}

--- a/pages/phases/job-announcement/create-announcement-on-usajobs.md
+++ b/pages/phases/job-announcement/create-announcement-on-usajobs.md
@@ -13,7 +13,7 @@ intro: When the content of your well-written job announcement is complete, creat
   {{ page.intro }}
 </p>
 
-Agencies participating in this process can use a new, plain-language USAJOBS job announcement template created specifically for this assessment strategy. The template pre-populates many of the JOA posting requirements, including the required Legal and Regulatory Guidance section. To create your posting, complete only these sections.
+Agencies using the SME-QA process can use a special, plain-language USAJOBS job announcement template created for this assessment strategy. The template pre-populates many of the JOA posting requirements, including the required Legal and Regulatory Guidance section. To create your posting, complete only these sections.
 
 ### 1. Title
 

--- a/pages/phases/reviewing-resumes/index.html
+++ b/pages/phases/reviewing-resumes/index.html
@@ -21,6 +21,15 @@ duration: Approximately 4 days
   {% include toolkit/reviewing-resumes.html %}
 </div>
 
+<div class="usa-alert usa-alert--info" >
+  <div class="usa-alert__body">
+    <h3 class="usa-alert__heading">Do not conduct a separate HR minimum qualification review.</h3>
+    <p class="usa-alert__text">
+      After SMEs have finished reviewing resumes, do not conduct a separate minimum qualification review. For more information, see "<a href="{{ site.baseurl }}/about/differences/#sme-assessment">How SME-QA is Different</a>."
+    </p>
+  </div>
+</div>
+
 {% assign page-list = '' | split: '' %}
 {% assign sub-pages = site.pages | where: "phase","reviewing-resumes" | sort: "sub-phase-order" %}
 {% for sub-page in sub-pages %}
@@ -37,15 +46,6 @@ duration: Approximately 4 days
     {{ sub-page.intro }}
   </p>
 {% endfor %}
-
-<div class="usa-alert usa-alert--info" >
-  <div class="usa-alert__body">
-    <h3 class="usa-alert__heading">Do not conduct a separate minimum qualification review</h3>
-    <p class="usa-alert__text">
-      After SMEs have finished reviewing resumes, do not conduct a separate minimum qualification review. For more information, see "<a href="{{ site.baseurl }}/about/differences/#sme-assessment">How our process is different</a>."
-    </p>
-  </div>
-</div>
 
 <!--
 {% assign hr-tasks = site.hr-tasks | where: "phase","reviewing-resumes" | where: "sub-phase","prep-for-resume-reviews" | where: "role","hr" %}


### PR DESCRIPTION
Closes https://github.com/usds/OPM_pilot/issues/729. We have a name for "the process" now, and it's SME-QA. This PR sprinkles that throughout the site wherever necessary.