### PR TITLE
Remove factually ambiguous information about civil service examinations

### DIFF
--- a/pages/home.html
+++ b/pages/home.html
@@ -11,7 +11,7 @@ permalink: /
   <div class="chp-home-hero__mask">
     <div class="chp-home-hero__body">
       <blockquote class="chp-home-hero__quote">
-         "It could be game changing. Hiring scientists, any specialized skill…I would absolutely recommend my office use it."
+         "It could be game-changing. Hiring scientists, any specialized skill…I would absolutely recommend my office use it."
          <span class="chp-home-hero__quote-attribution">
            – Technical Subject Matter Expert at HHS
          </span>

--- a/pages/home.html
+++ b/pages/home.html
@@ -26,7 +26,7 @@ permalink: /
   <div class="grid-row">
     <div class="grid-cell">
       <p class="chp-home-hero__caption">
-        1,300 typists take civil service examinations at McKinley High School in Washington, DC on July 9, 1936. Such examinations continued until 1981, when President Carter ended the practice. The Federal Government has not used examinations for hiring since&hellip;until now.
+        1,300 typists take civil service examinations at McKinley High School in Washington, DC on July 9, 1936. Such examinations continued until 1981.
       </p>
     </div>
   </div>


### PR DESCRIPTION
Currently, the caption for the hero image on the home page says:

> 1,300 typists take civil service examinations at McKinley High School in Washington, DC on July 9, 1936. Such examinations continued until 1981, when President Carter ended the practice. The Federal Government has not used examinations for hiring since... until now.

In actuality, examinations began again in 2015 when USA Hire was introduced. They take a different form from these proctored examinations, though, so I propose we leave the details to the end of the proctored examinations in 1981, which describes the image clearly, like so:

> 1,300 typists take civil service examinations at McKinley High School in Washington, DC on July 9, 1936. Such examinations continued until 1981.

cc @stephaniefaith @humancompanion-usds 